### PR TITLE
added support for multi sha certificate signing

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -99,6 +99,14 @@ inputs:
         - "Private-Signing"
         - "Auto-Dev-Signing"
         is_required: true
+    
+    - multiple_trusted_signing_certs_path:
+      opts:
+        title: "Multiple Trusted Signing Certificates file path"
+        summary: "Path to file containing multiple trusted signing certificates (or an EnvVar representing the path)"
+        description: "Path to file containing multiple trusted signing certificates, or an EnvVar representing its path (e.g. $MULTIPLE_TRUSTED_CERTS_PATH). Note: Multiple Trusted Signing Certificates can't work alongside 'Google Signing' or 'Private/Auto-Dev-Signing' categories."
+        is_required: false
+        category: Multiple Trusted Signing Certificates
         
     - gp_signing: "false"
       opts:

--- a/step_init.sh
+++ b/step_init.sh
@@ -69,6 +69,10 @@ if [[ -z $datadog_api_key ]];then
     datadog_api_key="_@_"
 fi
 
+if [[ -z $multiple_trusted_signing_certs_path ]];then
+    multiple_trusted_signing_certs_path="_@_"
+fi
+
 branch="RealStep"
 if [[ -n $APPDOME_BRANCH_ANDROID ]]; then
     branch=$APPDOME_BRANCH_ANDROID
@@ -78,5 +82,5 @@ echo "Running Branch: $branch"
 # step execusion
 git clone --branch $branch https://github.com/Appdome/bitrise-step-appdome-build-2secure-android.git  > /dev/null
 cd bitrise-step-appdome-build-2secure-android
-bash ./step.sh "$app_location" "$fusion_set_id" "$team_id" "$sign_method" "$gp_signing" "$google_fingerprint" "$fingerprint" "$build_logs" "$build_to_test" "$secondary_output" "$output_filename" "$workflow_output_logs" "$download_deobfuscation" "$crashlytics_app_id" "$datadog_api_key"
+bash ./step.sh "$app_location" "$fusion_set_id" "$team_id" "$sign_method" "$gp_signing" "$google_fingerprint" "$fingerprint" "$build_logs" "$build_to_test" "$secondary_output" "$output_filename" "$workflow_output_logs" "$download_deobfuscation" "$crashlytics_app_id" "$datadog_api_key" "$multiple_trusted_signing_certs_path"
 exit $(echo $?)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates the step’s signing-related interface and changes the `step.sh` argument list, which can break builds if the downstream script/branch isn’t updated in lockstep.
> 
> **Overview**
> Adds a new optional `multiple_trusted_signing_certs_path` step input (with docs noting it’s incompatible with Google/Private/Auto-Dev signing categories) to support multi-certificate trusted signing.
> 
> Updates `step_init.sh` to default the new input to the existing `_@_` sentinel when unset and to pass it as an additional argument to the cloned `step.sh` invocation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8befdea7cda21be943a9e69228f9e27f4d6b423d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->