### PR TITLE
Dev/multi sha support

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -275,10 +275,6 @@ if [[ $datadog_api_key != "_@_" ]]; then
 	dd="-dd_api_key ${datadog_api_key}"
 fi
 
-if [[ $APPDOME_DEBUG == "1" ]]; then
-	debug
-fi
-
 # Multiple Trusted Signing Certificates: cannot be used when Google Play Signing is true, or when Google Sign Fingerprint or Sign Fingerprint has a value
 # Multiple Trusted Signing Certificates: rules depend on sign method
 mtsc=""

--- a/step.sh
+++ b/step.sh
@@ -288,13 +288,10 @@ if [[ -n $multiple_trusted_signing_certs_path && $multiple_trusted_signing_certs
 	# Private-Signing / Auto-Dev-Signing: when using multiple_trusted_signing_certs_path, no SIGN_FINGERPRINT or Google signing allowed
 	elif [[ $sign_method == "Private-Signing" || $sign_method == "Auto-Dev-Signing" ]]; then
 		if [[ $gp_signing == "true" ]]; then
-			echo "Multiple Trusted Signing Certificates can't work alongside Google Play Signing when using Private/Auto-Dev-Signing. Please disable Google Play Signing.Exiting."
+			echo "Multiple Trusted Signing Certificates can't work alongside Google Play Signing when using Private/Auto-Dev-Signing. Please disable Google Play Signing. Exiting."
 			exit 1
 		fi
-		if [[ -n $google_fingerprint && $google_fingerprint != "_@_" ]]; then
-			echo "Multiple Trusted Signing Certificates can't work when Google Sign Fingerprint has a value (Private/Auto-Dev-Signing). Please disable Google Sign Signing. Exiting."
-			exit 1
-		fi
+		# SIGN_FINGERPRINT not allowed when using multiple_trusted_signing_certs_path (google_fingerprint is only used when gp_signing is true, already blocked above)
 		if [[ -n $fingerprint && $fingerprint != "_@_" ]]; then
 			echo "Multiple Trusted Signing Certificates can't work when Sign Fingerprint has a value (Private/Auto-Dev-Signing). Please remove Sign Fingerprint. Exiting."
 			exit 1

--- a/step.sh
+++ b/step.sh
@@ -260,6 +260,21 @@ if [[ $datadog_api_key != "_@_" ]]; then
 	dd="-dd_api_key ${datadog_api_key}"
 fi
 
+gp=""
+if [[ $gp_signing == "true" ]]; then
+	if [[ -z $google_fingerprint || $google_fingerprint == "_@_" ]]; then
+		if [[ -z $fingerprint ]]; then
+			echo "Google Sign Fingerprint must be provided for Google Play signing. Exiting."
+			exit 1
+		else
+			echo "Google Sign Fingerprint was not provided, will be using Sign Fringerprint instead."
+			google_fingerprint=$fingerprint
+		fi
+	fi
+	gp="--google_play_signing --signing_fingerprint ${google_fingerprint}"
+	sf=""
+fi
+
 # Multiple Trusted Signing Certificates: cannot be used when Google Play Signing is true, or when Google Sign Fingerprint or Sign Fingerprint has a value
 # Multiple Trusted Signing Certificates: rules depend on sign method
 mtsc=""
@@ -294,21 +309,6 @@ if [[ -n $multiple_trusted_signing_certs_path && $multiple_trusted_signing_certs
 		fi
 	fi
 	mtsc="--signing_fingerprint_list $multiple_trusted_signing_certs_path"
-fi
-
-gp=""
-if [[ $gp_signing == "true" ]]; then
-	if [[ -z $google_fingerprint || $google_fingerprint == "_@_" ]]; then
-		if [[ -z $fingerprint ]]; then
-			echo "Google Sign Fingerprint must be provided for Google Play signing. Exiting."
-			exit 1
-		else
-			echo "Google Sign Fingerprint was not provided, will be using Sign Fringerprint instead."
-			google_fingerprint=$fingerprint
-		fi
-	fi
-	gp="--google_play_signing --signing_fingerprint ${google_fingerprint}"
-	sf=""
 fi
 
 sign_command=""

--- a/step.sh
+++ b/step.sh
@@ -274,7 +274,11 @@ dd=""
 if [[ $datadog_api_key != "_@_" ]]; then
 	dd="-dd_api_key ${datadog_api_key}"
 fi
-debug
+
+if [[ $APPDOME_DEBUG == "1" ]]; then
+	debug
+fi
+
 # Multiple Trusted Signing Certificates: cannot be used when Google Play Signing is true, or when Google Sign Fingerprint or Sign Fingerprint has a value
 mtsc=""
 if [[ -n $multiple_trusted_signing_certs_path && $multiple_trusted_signing_certs_path != "_@_" ]]; then

--- a/step.sh
+++ b/step.sh
@@ -274,7 +274,7 @@ dd=""
 if [[ $datadog_api_key != "_@_" ]]; then
 	dd="-dd_api_key ${datadog_api_key}"
 fi
-
+debug
 # Multiple Trusted Signing Certificates: cannot be used when Google Play Signing is true, or when Google Sign Fingerprint or Sign Fingerprint has a value
 mtsc=""
 if [[ -n $multiple_trusted_signing_certs_path && $multiple_trusted_signing_certs_path != "_@_" ]]; then

--- a/step.sh
+++ b/step.sh
@@ -280,21 +280,32 @@ if [[ $APPDOME_DEBUG == "1" ]]; then
 fi
 
 # Multiple Trusted Signing Certificates: cannot be used when Google Play Signing is true, or when Google Sign Fingerprint or Sign Fingerprint has a value
+# Multiple Trusted Signing Certificates: rules depend on sign method
 mtsc=""
 if [[ -n $multiple_trusted_signing_certs_path && $multiple_trusted_signing_certs_path != "_@_" ]]; then
-	if [[ $gp_signing == "true" ]]; then
-		echo "Multiple Trusted Signing Certificates can't work alongside Google Play Signing (true). Exiting."
-		exit 1
+	# On-Appdome: SIGN_FINGERPRINT is ignored; multiple_trusted_signing_certs_path allowed only when gp_signing is false
+	if [[ $sign_method == "On-Appdome" ]]; then
+		if [[ $gp_signing == "true" ]]; then
+			echo "Multiple Trusted Signing Certificates can't work alongside Google Play Signing (true). Exiting."
+			exit 1
+		fi
+		mtsc="--signing_fingerprint_list $multiple_trusted_signing_certs_path"
+	# Private-Signing / Auto-Dev-Signing: when using multiple_trusted_signing_certs_path, no SIGN_FINGERPRINT or Google signing allowed
+	elif [[ $sign_method == "Private-Signing" || $sign_method == "Auto-Dev-Signing" ]]; then
+		if [[ $gp_signing == "true" ]]; then
+			echo "Multiple Trusted Signing Certificates can't work alongside Google Play Signing when using Private/Auto-Dev-Signing. Exiting."
+			exit 1
+		fi
+		if [[ -n $google_fingerprint && $google_fingerprint != "_@_" ]]; then
+			echo "Multiple Trusted Signing Certificates can't work when Google Sign Fingerprint has a value (Private/Auto-Dev-Signing). Exiting."
+			exit 1
+		fi
+		if [[ -n $fingerprint && $fingerprint != "_@_" ]]; then
+			echo "Multiple Trusted Signing Certificates can't work when Sign Fingerprint has a value (Private/Auto-Dev-Signing). Exiting."
+			exit 1
+		fi
+		mtsc="--signing_fingerprint_list $multiple_trusted_signing_certs_path"
 	fi
-	if [[ -n $google_fingerprint && $google_fingerprint != "_@_" ]]; then
-		echo "Multiple Trusted Signing Certificates can't work when Google Sign Fingerprint has a value. Exiting."
-		exit 1
-	fi
-	if [[ -n $fingerprint && $fingerprint != "_@_" ]]; then
-		echo "Multiple Trusted Signing Certificates can't work when Sign Fingerprint has a value. Exiting."
-		exit 1
-	fi
-	mtsc="--signing_fingerprint_list $multiple_trusted_signing_certs_path"
 fi
 
 sign_command=""

--- a/step.sh
+++ b/step.sh
@@ -238,21 +238,6 @@ else
 	workflow_output_logs=""
 fi
 
-gp=""
-if [[ $gp_signing == "true" ]]; then
-	if [[ -z $google_fingerprint || $google_fingerprint == "_@_" ]]; then
-		if [[ -z $fingerprint ]]; then
-			echo "Google Sign Fingerprint must be provided for Google Play signing. Exiting."
-			exit 1
-		else
-			echo "Google Sign Fingerprint was not provided, will be using Sign Fringerprint instead."
-			google_fingerprint=$fingerprint
-		fi
-	fi
-	gp="--google_play_signing --signing_fingerprint ${google_fingerprint}"
-	sf=""
-fi
-
 bl=""
 if [[ $build_logs == "true" ]]; then
 	bl="--build_logs"
@@ -282,21 +267,21 @@ if [[ -n $multiple_trusted_signing_certs_path && $multiple_trusted_signing_certs
 	# On-Appdome: SIGN_FINGERPRINT is ignored; multiple_trusted_signing_certs_path allowed only when gp_signing is false
 	if [[ $sign_method == "On-Appdome" ]]; then
 		if [[ $gp_signing == "true" ]]; then
-			echo "Multiple Trusted Signing Certificates can't work alongside Google Play Signing (true). Exiting."
+			echo "Multiple Trusted Signing Certificates can't work alongside Google Play Signing (true). Please disable Google Play Signing. Exiting."
 			exit 1
 		fi
 	# Private-Signing / Auto-Dev-Signing: when using multiple_trusted_signing_certs_path, no SIGN_FINGERPRINT or Google signing allowed
 	elif [[ $sign_method == "Private-Signing" || $sign_method == "Auto-Dev-Signing" ]]; then
 		if [[ $gp_signing == "true" ]]; then
-			echo "Multiple Trusted Signing Certificates can't work alongside Google Play Signing when using Private/Auto-Dev-Signing. Exiting."
+			echo "Multiple Trusted Signing Certificates can't work alongside Google Play Signing when using Private/Auto-Dev-Signing. Please disable Google Play Signing.Exiting."
 			exit 1
 		fi
 		if [[ -n $google_fingerprint && $google_fingerprint != "_@_" ]]; then
-			echo "Multiple Trusted Signing Certificates can't work when Google Sign Fingerprint has a value (Private/Auto-Dev-Signing). Exiting."
+			echo "Multiple Trusted Signing Certificates can't work when Google Sign Fingerprint has a value (Private/Auto-Dev-Signing). Please disable Google Sign Signing. Exiting."
 			exit 1
 		fi
 		if [[ -n $fingerprint && $fingerprint != "_@_" ]]; then
-			echo "Multiple Trusted Signing Certificates can't work when Sign Fingerprint has a value (Private/Auto-Dev-Signing). Exiting."
+			echo "Multiple Trusted Signing Certificates can't work when Sign Fingerprint has a value (Private/Auto-Dev-Signing). Please remove Sign Fingerprint. Exiting."
 			exit 1
 		fi
 	fi
@@ -309,6 +294,21 @@ if [[ -n $multiple_trusted_signing_certs_path && $multiple_trusted_signing_certs
 		fi
 	fi
 	mtsc="--signing_fingerprint_list $multiple_trusted_signing_certs_path"
+fi
+
+gp=""
+if [[ $gp_signing == "true" ]]; then
+	if [[ -z $google_fingerprint || $google_fingerprint == "_@_" ]]; then
+		if [[ -z $fingerprint ]]; then
+			echo "Google Sign Fingerprint must be provided for Google Play signing. Exiting."
+			exit 1
+		else
+			echo "Google Sign Fingerprint was not provided, will be using Sign Fringerprint instead."
+			google_fingerprint=$fingerprint
+		fi
+	fi
+	gp="--google_play_signing --signing_fingerprint ${google_fingerprint}"
+	sf=""
 fi
 
 sign_command=""

--- a/step.sh
+++ b/step.sh
@@ -285,7 +285,6 @@ if [[ -n $multiple_trusted_signing_certs_path && $multiple_trusted_signing_certs
 			echo "Multiple Trusted Signing Certificates can't work alongside Google Play Signing (true). Exiting."
 			exit 1
 		fi
-		mtsc="--signing_fingerprint_list $multiple_trusted_signing_certs_path"
 	# Private-Signing / Auto-Dev-Signing: when using multiple_trusted_signing_certs_path, no SIGN_FINGERPRINT or Google signing allowed
 	elif [[ $sign_method == "Private-Signing" || $sign_method == "Auto-Dev-Signing" ]]; then
 		if [[ $gp_signing == "true" ]]; then
@@ -300,8 +299,16 @@ if [[ -n $multiple_trusted_signing_certs_path && $multiple_trusted_signing_certs
 			echo "Multiple Trusted Signing Certificates can't work when Sign Fingerprint has a value (Private/Auto-Dev-Signing). Exiting."
 			exit 1
 		fi
-		mtsc="--signing_fingerprint_list $multiple_trusted_signing_certs_path"
 	fi
+	if [[ ! -f $multiple_trusted_signing_certs_path ]]; then
+		echo "Multiple Trusted Signing Certificates file not found. trying to download it from $multiple_trusted_signing_certs_path."
+		multiple_trusted_signing_certs_path=$(download_file $multiple_trusted_signing_certs_path)
+		if [[ ! -f $multiple_trusted_signing_certs_path ]]; then
+			echo "Failed to download Multiple Trusted Signing Certificates file. Exiting."
+			exit 1
+		fi
+	fi
+	mtsc="--signing_fingerprint_list $multiple_trusted_signing_certs_path"
 fi
 
 sign_command=""

--- a/step.sh
+++ b/step.sh
@@ -125,6 +125,7 @@ print_all_params() {
 	echo "Deobfuscation mapping files location: $deob_output"
 	echo "Crashlytics app id: $app_id"
 	echo "Datadog API key: $datadog_api_key"
+	echo "Multiple trusted signing certs path: $multiple_trusted_signing_certs_path"
 	echo "-----------------------------------------"
 }
 
@@ -154,6 +155,7 @@ workflow_output_logs=${12}
 download_deobfuscation=${13}
 app_id=${14}
 datadog_api_key=${15}
+multiple_trusted_signing_certs_path=${16}
 
 
 if [[ -n $APPDOME_PIPELINE_SIGNING_METHOD ]]; then
@@ -273,6 +275,24 @@ if [[ $datadog_api_key != "_@_" ]]; then
 	dd="-dd_api_key ${datadog_api_key}"
 fi
 
+# Multiple Trusted Signing Certificates: cannot be used when Google Play Signing is true, or when Google Sign Fingerprint or Sign Fingerprint has a value
+mtsc=""
+if [[ -n $multiple_trusted_signing_certs_path && $multiple_trusted_signing_certs_path != "_@_" ]]; then
+	if [[ $gp_signing == "true" ]]; then
+		echo "Multiple Trusted Signing Certificates can't work alongside Google Play Signing (true). Exiting."
+		exit 1
+	fi
+	if [[ -n $google_fingerprint && $google_fingerprint != "_@_" ]]; then
+		echo "Multiple Trusted Signing Certificates can't work when Google Sign Fingerprint has a value. Exiting."
+		exit 1
+	fi
+	if [[ -n $fingerprint && $fingerprint != "_@_" ]]; then
+		echo "Multiple Trusted Signing Certificates can't work when Sign Fingerprint has a value. Exiting."
+		exit 1
+	fi
+	mtsc="--signing_fingerprint_list $multiple_trusted_signing_certs_path"
+fi
+
 sign_command=""
 cmd=""
 
@@ -291,6 +311,7 @@ case $sign_method in
 							$sign_command \
 							$gp \
 							$sf \
+							$mtsc \
 							$bl \
 							$btv \
 							$so \
@@ -319,6 +340,7 @@ case $sign_method in
 							$sign_command \
 							$gp \
 							$sf \
+							$mtsc \
 							$bl \
 							$btv \
 							$dso \
@@ -394,6 +416,7 @@ case $sign_method in
 							--keystore_alias "$keystore_alias" \
 							--key_pass "$private_key_password" \
 							$gp \
+							$mtsc \
 							$bl \
 							$btv \
 							$so \


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates the Bitrise step’s signing argument handling and adds new validation paths; misconfiguration could block builds or change which certificate fingerprints are accepted during signing.
> 
> **Overview**
> Adds a new step input `multiple_trusted_signing_certs_path` and wires it through to `appdome_api.sh` via `--signing_fingerprint_list` for all signing modes.
> 
> Introduces validation rules and mutual-exclusion logic between *Multiple Trusted Signing Certificates*, Google Play signing, and `SIGN_FINGERPRINT` (with sign-method-specific constraints), including auto-download of the cert list file when a remote path is provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73d8f27ed4764c90ffd8937fada6cb93aebcd111. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->