### PR TITLE
change ui to support keystore configuration

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -99,6 +99,14 @@ inputs:
         - "Private-Signing"
         - "Auto-Dev-Signing"
         is_required: true
+
+    - android_keystore_url_env:
+      opts:
+        title: "Keystore URL — env var name"
+        summary: "Bitrise Code Signing keystore URL variable; password, alias, and key password env names are derived from it."
+        description: "Variable name from Project settings → Code Signing (no $). E.g. BITRISEIO_ANDROID_KEYSTORE_4_URL. Leave empty for default primary or _1 keystore."
+        is_required: false
+        category: On-Appdome Signing
     
     - multiple_trusted_signing_certs_path:
       opts:

--- a/step_init.sh
+++ b/step_init.sh
@@ -23,7 +23,7 @@ set -e
 
 # This is step_init.sh file for Android apps
 
-# version: 3.4
+# version: 3.6
 
 # parameters validation:
 if [[ -z $APPDOME_API_KEY ]]; then
@@ -71,6 +71,53 @@ fi
 
 if [[ -z $multiple_trusted_signing_certs_path ]];then
     multiple_trusted_signing_certs_path="_@_"
+fi
+
+# Optional: pick a Bitrise Code Signing keystore by the *URL* env var name; password / alias /
+# private key password names are derived from that name.
+#   BITRISEIO_ANDROID_KEYSTORE_4_URL  -> ..._4_PASSWORD, ..._4_ALIAS, ..._4_PRIVATE_KEY_PASSWORD
+#   BITRISEIO_ANDROID_KEYSTORE_URL_4  -> ..._PASSWORD_4, ..._ALIAS_4, ..._PRIVATE_KEY_PASSWORD_4
+# Remaps into BITRISEIO_ANDROID_KEYSTORE_* so RealStep step.sh is unchanged.
+if [[ -n "${android_keystore_url_env:-}" ]]; then
+    if [[ ! $android_keystore_url_env =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+        echo "Invalid android_keystore_url_env name: '${android_keystore_url_env}'"
+        exit 1
+    fi
+    if [[ $android_keystore_url_env =~ ^BITRISEIO_ANDROID_KEYSTORE_URL_(.+)$ ]]; then
+        _ks_suf="${BASH_REMATCH[1]}"
+        _ks_pass_ref="BITRISEIO_ANDROID_KEYSTORE_PASSWORD_${_ks_suf}"
+        _ks_alias_ref="BITRISEIO_ANDROID_KEYSTORE_ALIAS_${_ks_suf}"
+        _ks_keypass_ref="BITRISEIO_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD_${_ks_suf}"
+    elif [[ $android_keystore_url_env =~ ^(.+)_URL$ ]]; then
+        _ks_base="${BASH_REMATCH[1]}"
+        _ks_pass_ref="${_ks_base}_PASSWORD"
+        _ks_alias_ref="${_ks_base}_ALIAS"
+        _ks_keypass_ref="${_ks_base}_PRIVATE_KEY_PASSWORD"
+    else
+        echo "android_keystore_url_env must end with _URL, e.g. BITRISEIO_ANDROID_KEYSTORE_4_URL or BITRISEIO_ANDROID_KEYSTORE_URL_4. Got: '${android_keystore_url_env}'"
+        exit 1
+    fi
+    for _ks_slot in _ks_pass_ref _ks_alias_ref _ks_keypass_ref; do
+        eval "_n=\$$_ks_slot"
+        if [[ ! $_n =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+            echo "Derived invalid env var name: '${_n}'"
+            exit 1
+        fi
+    done
+    echo "Derived keystore env vars from ${android_keystore_url_env}: ${_ks_pass_ref}, ${_ks_alias_ref}, ${_ks_keypass_ref}"
+    eval "_ks_url_val=\$$android_keystore_url_env"
+    eval "_ks_pass_val=\$$_ks_pass_ref"
+    eval "_ks_alias_val=\$$_ks_alias_ref"
+    eval "_ks_keypass_val=\$$_ks_keypass_ref"
+    if [[ -z $_ks_url_val ]]; then
+        echo "Keystore URL is empty: env var '${android_keystore_url_env}' is unset or empty."
+        exit 1
+    fi
+    export BITRISEIO_ANDROID_KEYSTORE_URL="$_ks_url_val"
+    export BITRISEIO_ANDROID_KEYSTORE_PASSWORD="$_ks_pass_val"
+    export BITRISEIO_ANDROID_KEYSTORE_ALIAS="$_ks_alias_val"
+    export BITRISEIO_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD="$_ks_keypass_val"
+    echo "Using keystore from Code Signing env vars: ${android_keystore_url_env} (remapped to BITRISEIO_ANDROID_KEYSTORE_URL)."
 fi
 
 branch="RealStep"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches Android signing configuration by dynamically remapping keystore-related environment variables; misconfiguration or unexpected env var naming could cause build/sign failures.
> 
> **Overview**
> Adds a new optional `android_keystore_url_env` step input to let users choose a specific Bitrise Code Signing keystore by providing its *URL env var name*.
> 
> Updates `step_init.sh` (v3.6) to validate the provided env var name, derive the corresponding password/alias/key-password env var names, and export them into the default `BITRISEIO_ANDROID_KEYSTORE_*` variables so the downstream `step.sh` signing behavior remains unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78745644884ada60181d926689cf9b72826bf92b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->